### PR TITLE
[#68] Improve logging of 'clinfo' command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # OpenCL for Visual Studio Code Change Log
 
+## Version 0.8.4: August 13, 2024
+
+This release improves the logging system.
+
+Dependencies have been updated to address potential vulnerabilities.
+
 ## Version 0.8.3: February 25, 2024
 
 This release introduces a language server for Linux ARM64 (AArch64).

--- a/DEV.md
+++ b/DEV.md
@@ -54,8 +54,13 @@ Archive the executable
 Perform the notarization
 
 ```shell
+(cd ./bin/darwin; xcrun notarytool submit opencl-language-server.zip --keychain-profile $PROFILE --wait)
+```
+
+Troubleshooting
+
+```shell
 pushd ./bin/darwin
-xcrun notarytool submit opencl-language-server.zip --keychain-profile $PROFILE --wait
 xcrun notarytool history --keychain-profile $PROFILE
 xcrun notarytool info --keychain-profile $PROFILE $SUBMISSION_ID
 xcrun notarytool log --keychain-profile $PROFILE $SUBMISSION_ID

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "vscode-opencl-client",
-	"version": "0.8.3",
+	"version": "0.8.4",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "vscode-opencl-client",
-			"version": "0.8.3",
+			"version": "0.8.4",
 			"license": "MIT",
 			"dependencies": {
 				"child-process-promise": "^2.2.1",

--- a/client/package.json
+++ b/client/package.json
@@ -3,7 +3,7 @@
 	"description": "OpenCL for Visual Studio Code",
 	"author": "galarius",
 	"license": "MIT",
-	"version": "0.8.3",
+	"version": "0.8.4",
 	"publisher": "galarius",
 	"repository": {
 		"type": "git",

--- a/client/src/commands/tmp.ts
+++ b/client/src/commands/tmp.ts
@@ -1,0 +1,21 @@
+'use strict';
+
+import * as os from 'os';
+import * as fs from 'fs';
+
+export function mktmp(): string {
+    try {
+        return fs.mkdtempSync(os.tmpdir());
+    } catch (e) {
+        console.error(`An error has occurred while crating the temp folder. Error: ${e}`);
+    }
+    return null
+}
+
+export function rmtmp(path: string) {
+    try {
+        fs.rmSync(path, { recursive: true });
+    } catch (e) {
+        console.error(`An error occurred while removing the temp folder at '${path}'. Error: ${e}`);
+    }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "vscode-opencl",
-    "version": "0.8.3",
+    "version": "0.8.4",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "vscode-opencl",
-            "version": "0.8.3",
+            "version": "0.8.4",
             "hasInstallScript": true,
             "license": "SEE LICENSE IN LICENSE.txt",
             "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -3236,12 +3236,12 @@
             }
         },
         "node_modules/braces": {
-            "version": "3.0.2",
-            "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
-            "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+            "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
             "dev": true,
             "dependencies": {
-                "fill-range": "^7.0.1"
+                "fill-range": "^7.1.1"
             },
             "engines": {
                 "node": ">=8"
@@ -3879,9 +3879,9 @@
             }
         },
         "node_modules/fill-range": {
-            "version": "7.0.1",
-            "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
-            "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+            "version": "7.1.1",
+            "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+            "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
             "dev": true,
             "dependencies": {
                 "to-regex-range": "^5.0.1"

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "vscode-opencl",
     "displayName": "OpenCL",
     "description": "OpenCL for Visual Studio Code",
-    "version": "0.8.3",
+    "version": "0.8.4",
     "publisher": "galarius",
     "icon": "images/OpenCL_128x.png",
     "author": {


### PR DESCRIPTION
* Fixed an issue where logs were sometimes not flushed to file. This ensures that all log entries are now reliably written to the log file periodically and on process shutdown.
* Expanded logging coverage, adding more detailed log messages throughout the implementation of the clinfo command.
* Added macOS-specific `oslogger` (subsystem: `com.galarius.vscode-opencl.server`)
* Updated dependencies
