### PR TITLE
Fix language server not being stopped on deactivation

### DIFF
--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -14,7 +14,7 @@ import { getOpenCLTasks, buildTask, OpenCLDeviceDetector } from './providers/tas
 import { CreateLanguageServer } from "./providers/server/server";
 import { OpenCLDevicesProvider, OpenCLDeviceTreeItem } from "./providers/view/devices";
 
-let client: LanguageClient;
+let client: LanguageClient | undefined;
 
 function stateToString(state: State): string {
     const stateMap: { [key in State]?: string } = {
@@ -147,7 +147,7 @@ export function activate(context: vscode.ExtensionContext) {
     let configuration = vscode.workspace.getConfiguration('OpenCL.server', null)
     if (configuration.get('enable', true)) {
         let output: vscode.OutputChannel = vscode.window.createOutputChannel('OpenCL Language Server')
-        let client = CreateLanguageServer(OPECL_LANGUAGE_ID, output, context.extensionUri)
+        client = CreateLanguageServer(OPECL_LANGUAGE_ID, output, context.extensionUri)
         if (typeof client === 'undefined') {
             return
         }

--- a/client/src/providers/server/server.ts
+++ b/client/src/providers/server/server.ts
@@ -30,7 +30,7 @@ function GetLanguageServerDebugPath(extensionUri: vscode.Uri): string | undefine
     return process.env.OPENCL_LANGUAGE_SERVER
 }
 
-function CreateLanguageServer(selector: vscode.DocumentFilter, output: vscode.OutputChannel, extensionUri: vscode.Uri): LanguageClient {    
+function CreateLanguageServer(selector: vscode.DocumentFilter, output: vscode.OutputChannel, extensionUri: vscode.Uri): LanguageClient | undefined {
     var serverPath = GetLanguageServerPath(extensionUri)
     if(!serverPath ) { 
         output.appendLine("OpenCL Language Server is not available for platform: " + os.platform() + ", arch: " + os.arch())


### PR DESCRIPTION
The opencl-language-server process is running infinitely because it opens an OpenCL context and does not close on `deactivate` call. This happens because `client` variable is being shadowed by local `client` variable